### PR TITLE
DDCE-3903 | SBT and copyright headers update.

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/binders/PathBinders.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/binders/PathBinders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/binders/SimpleObjectBinder.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/binders/SimpleObjectBinder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/config/AppConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/config/AppConfigSource.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/config/AppConfigSource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/config/ConfigModule.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/config/ConfigModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/config/ErrorHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/connectors/CurrencyConversionConnector.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/connectors/CurrencyConversionConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/connectors/EmailConnector.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/connectors/EmailConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/connectors/EoriCheckConnector.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/connectors/EoriCheckConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/controllers/CalculationController.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/controllers/CalculationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/controllers/DeclarationController.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/controllers/DeclarationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/controllers/EoriCheckNumberController.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/controllers/EoriCheckNumberController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/controllers/HmrcExchangeRateController.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/controllers/HmrcExchangeRateController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/DeclarationEmailInfo.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/DeclarationEmailInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Amendment.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Amendment.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/AmountInPence.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/AmountInPence.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/ConversionRatePeriod.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/ConversionRatePeriod.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Country.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Country.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Currency.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Currency.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/CustomsAgent.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/CustomsAgent.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Declaration.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Declaration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/DeclarationGoods.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/DeclarationGoods.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/DeclarationId.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/DeclarationId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/DeclarationType.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/DeclarationType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Email.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Email.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Enum.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Enum.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Eori.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Eori.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/ExchangeRateURL.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/ExchangeRateURL.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/GoodsDestination.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/GoodsDestination.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/GoodsVatRate.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/GoodsVatRate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/JourneyDetails.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/JourneyDetails.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/JourneyDetailsEntry.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/JourneyDetailsEntry.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/JourneyType.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/JourneyType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/MibReference.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/MibReference.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Name.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Name.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/PaymentStatus.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/PaymentStatus.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Port.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/Port.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/PurchaseDetails.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/PurchaseDetails.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/SessionId.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/SessionId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/TotalCalculationResult.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/TotalCalculationResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/YesNo.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/YesNo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/YesNoDontKnow.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/YesNoDontKnow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/addresslookup/Address.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/addresslookup/Address.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/calculation/CalculationAmendRequest.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/calculation/CalculationAmendRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/calculation/CalculationRequest.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/calculation/CalculationRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/calculation/CalculationResponse.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/calculation/CalculationResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/calculation/CalculationResult.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/calculation/CalculationResult.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/calculation/CalculationResults.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/calculation/CalculationResults.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/calculation/ThresholdCheck.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/calculation/ThresholdCheck.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/checkeori/CheckEoriAddress.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/checkeori/CheckEoriAddress.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/checkeori/CheckResponse.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/checkeori/CheckResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/api/checkeori/CompanyDetails.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/api/checkeori/CompanyDetails.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/audit/RefundableDeclaration.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/audit/RefundableDeclaration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/core/BusinessError.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/core/BusinessError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/core/PaymentCallbackRequest.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/core/PaymentCallbackRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/repositories/CryptoDeclarationRepositoryImpl.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/repositories/CryptoDeclarationRepositoryImpl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/repositories/DeclarationRepository.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/repositories/DeclarationRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/service/Auditor.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/service/Auditor.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/service/CalculationService.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/service/CalculationService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/service/DeclarationDateOrdering.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/service/DeclarationDateOrdering.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/service/DeclarationService.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/service/DeclarationService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/service/EmailService.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/service/EmailService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/testonly/QATestingController.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/testonly/QATestingController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/util/DataModelEnriched.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/util/DataModelEnriched.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/util/DateUtils.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/util/DateUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/util/PagerDutyHelper.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/util/PagerDutyHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/merchandiseinbaggage/util/Utils.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/util/Utils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2023 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.7.2

--- a/test/resources/test.application.conf
+++ b/test/resources/test.application.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2023 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/BaseSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/BaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/CoreTestData.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/CoreTestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,14 @@ package uk.gov.hmrc.merchandiseinbaggage
 
 import java.time.{LocalDate, LocalDateTime}
 import java.util.UUID.randomUUID
-
 import uk.gov.hmrc.merchandiseinbaggage.model.api.DeclarationType.Import
 import uk.gov.hmrc.merchandiseinbaggage.model.api.GoodsDestinations.GreatBritain
 import uk.gov.hmrc.merchandiseinbaggage.model.api._
 import uk.gov.hmrc.merchandiseinbaggage.model.api.addresslookup.{Address, AddressLookupCountry}
 import uk.gov.hmrc.merchandiseinbaggage.model.api.calculation.{CalculationResult, CalculationResults}
 import uk.gov.hmrc.merchandiseinbaggage.model.api.checkeori.{CheckEoriAddress, CheckResponse, CompanyDetails}
+
+import java.time.temporal.ChronoUnit
 
 trait CoreTestData {
 
@@ -84,7 +85,7 @@ trait CoreTestData {
       None,
       anEori,
       aJourneyDetails,
-      LocalDateTime.now,
+      LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS),
       aMibReference,
       Some(aTotalCalculationResult),
       paymentStatus = Some(Paid),
@@ -125,7 +126,7 @@ trait CoreTestData {
 
   val aAmendment = Amendment(
     1,
-    LocalDateTime.now,
+    LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS),
     aDeclarationGoods,
     Some(aTotalCalculationResult),
     None,
@@ -134,7 +135,7 @@ trait CoreTestData {
 
   val aAmendmentWithNoTax = Amendment(
     1,
-    LocalDateTime.now,
+    LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS),
     aDeclarationGoods,
     Some(zeroTotalCalculationResult),
     None,
@@ -153,7 +154,7 @@ trait CoreTestData {
       None,
       anEori,
       aJourneyDetails,
-      LocalDateTime.now,
+      LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS),
       aMibReference,
       Some(aTotalCalculationResult),
       paymentStatus = Some(Paid),

--- a/test/uk/gov/hmrc/merchandiseinbaggage/WireMock.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/WireMock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/connectors/CurrencyConversionConnectorSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/connectors/CurrencyConversionConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/connectors/EmailConnectorSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/connectors/EmailConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/connectors/EoriCheckConnectorSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/connectors/EoriCheckConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/controllers/CalculationControllerSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/controllers/CalculationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.merchandiseinbaggage.controllers
 
 import java.time.{LocalDate, LocalDateTime}
-
 import cats.data.OptionT
 import org.scalamock.scalatest.MockFactory
 import play.api.libs.json.Json
@@ -30,6 +29,7 @@ import uk.gov.hmrc.merchandiseinbaggage.model.api.calculation._
 import uk.gov.hmrc.merchandiseinbaggage.service.CalculationService
 import uk.gov.hmrc.merchandiseinbaggage.{BaseSpecWithApplication, CoreTestData}
 
+import java.time.temporal.ChronoUnit
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -59,7 +59,7 @@ class CalculationControllerSpec extends BaseSpecWithApplication with CoreTestDat
 
   s"handle amends calculations delegating to CalculationService" in {
     val controller = new CalculationController(mockService, component)
-    val amend = Amendment(111, LocalDateTime.now, DeclarationGoods(Seq(aImportGoods)))
+    val amend = Amendment(111, LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS), DeclarationGoods(Seq(aImportGoods)))
     val calculationRequest = CalculationAmendRequest(Some(amend), Some(GreatBritain), aDeclarationId)
 
     (mockService

--- a/test/uk/gov/hmrc/merchandiseinbaggage/controllers/DeclarationControllerSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/controllers/DeclarationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/controllers/EoriCheckNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/controllers/EoriCheckNumberControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/controllers/HmrcExchangeRateControllerSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/controllers/HmrcExchangeRateControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/model/api/DeclarationSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/model/api/DeclarationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/model/api/EoriNumberSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/model/api/EoriNumberSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/model/api/calculation/ThresholdCheckSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/model/api/calculation/ThresholdCheckSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/pact/PactVerifySuite.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/pact/PactVerifySuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/pact/VerifyContractSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/pact/VerifyContractSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/repositories/CryptoDeclarationRepositoryImplSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/repositories/CryptoDeclarationRepositoryImplSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/repositories/DeclarationRepositorySpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/repositories/DeclarationRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/service/AuditorSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/service/AuditorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/service/CalculationServiceSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/service/CalculationServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package uk.gov.hmrc.merchandiseinbaggage.service
 
 import java.time.LocalDate.now
 import java.time.{LocalDate, LocalDateTime}
-
 import cats.data.EitherT
 import com.softwaremill.quicklens._
 import org.scalamock.scalatest.MockFactory
@@ -30,6 +29,7 @@ import uk.gov.hmrc.merchandiseinbaggage.model.api.calculation._
 import uk.gov.hmrc.merchandiseinbaggage.model.api._
 import uk.gov.hmrc.merchandiseinbaggage.{BaseSpecWithApplication, CoreTestData}
 
+import java.time.temporal.ChronoUnit
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -267,7 +267,7 @@ class CalculationServiceSpec extends BaseSpecWithApplication with ScalaFutures w
       )
       .twice()
 
-    val amends = Amendment(111, LocalDateTime.now(), DeclarationGoods(Seq(importGoods)))
+    val amends = Amendment(111, LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS), DeclarationGoods(Seq(importGoods)))
     val eventualResult =
       service.calculateAmendPlusOriginal(CalculationAmendRequest(Some(amends), Some(GreatBritain), declaration.declarationId))
 

--- a/test/uk/gov/hmrc/merchandiseinbaggage/service/DeclarationDateOrderingSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/service/DeclarationDateOrderingSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,17 @@
 package uk.gov.hmrc.merchandiseinbaggage.service
 
 import java.time.LocalDateTime
-
 import uk.gov.hmrc.merchandiseinbaggage.model.api.DeclarationId
 import uk.gov.hmrc.merchandiseinbaggage.{BaseSpec, CoreTestData}
+
+import java.time.temporal.ChronoUnit
 
 class DeclarationDateOrderingSpec extends BaseSpec with CoreTestData {
 
   "find latest of a list declaration created date" in new DeclarationDateOrdering {
     private val declaration = aDeclaration
     private val newest = 20
-    private val now = LocalDateTime.now
+    private val now = LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS)
     private val declarations = (1 to newest).toList.map(idx =>
       declaration.copy(declarationId = DeclarationId(idx.toString)).copy(dateOfDeclaration = now.plusMinutes(idx)))
 

--- a/test/uk/gov/hmrc/merchandiseinbaggage/service/DeclarationServiceSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/service/DeclarationServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/service/EmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/service/EmailServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/stubs/CurrencyConversionStub.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/stubs/CurrencyConversionStub.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/stubs/EmailStub.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/stubs/EmailStub.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/stubs/EoriCheckStub.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/stubs/EoriCheckStub.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/merchandiseinbaggage/util/DateUtilsSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/util/DateUtilsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
SBT updated to solve issues when running service on M1/M2 Apple machines with Java 11.
Updated copyright headers.
Added .truncatedTo to LocalDateTime.now in tests to keep previous precision.