### PR TITLE
DDCE-4438 - Mongo upgrade 0.68.x to 1.3.x

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,8 +5,8 @@ import sbt._
 object AppDependencies {
 
   private val pactVersion          = "4.4.0"
-  private val hmrcMongoVersion     = "0.68.0"
-  private val bootstrapPlayVersion = "7.15.0"
+  private val hmrcMongoVersion     = "1.3.0"
+  private val bootstrapPlayVersion = "7.20.0"
 
   val compile = Seq(
     ws,


### PR DESCRIPTION
Cant update other deps every step left or right in refactoring or updating deps is creating conflict in between these, need to get rid of scalapact and do other cleanup but it will be done after handover to team TC